### PR TITLE
Improve tree validation speed

### DIFF
--- a/benches/smt_benchmark.rs
+++ b/benches/smt_benchmark.rs
@@ -3,7 +3,7 @@ extern crate criterion;
 
 mod string_key;
 
-use criterion::Criterion;
+use criterion::{BenchmarkId, Criterion};
 use rand::{thread_rng, Rng};
 use nam_sparse_merkle_tree::{
     sha256::Sha256Hasher, default_store::DefaultStore,
@@ -48,29 +48,37 @@ fn random_stringsmt(update_count: usize, rng: &mut impl Rng) -> (StringSmt, Vec<
 }
 
 fn bench_hashes(c: &mut Criterion) {
-    c.bench_function_over_inputs(
-        "ShaSmt update",
-        |b, &&size| {
-            b.iter(|| {
-                let mut rng = thread_rng();
-                random_shasmt(size, &mut rng)
-            });
-        },
-        &[100, 10_000],
-    );
+    let mut group = c.benchmark_group("ShaSmt update");
+    for size in [100, 10_000].iter() {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(size),
+            size,
+            |b, &size| {
+                b.iter(|| {
+                    let mut rng = thread_rng();
+                    random_shasmt(size, &mut rng)
+                });
+            }
+        );
+    }
+    group.finish();
 
-    c.bench_function_over_inputs(
-        "ShaSmt get",
-        |b, &&size| {
-            let mut rng = thread_rng();
-            let (smt, _keys) = random_shasmt(size, &mut rng);
-            b.iter(|| {
-                let key = random_h256(&mut rng).into();
-                smt.get(&key).unwrap();
-            });
-        },
-        &[5_000, 10_000],
-    );
+    let mut group = c.benchmark_group("ShaSmt get");
+    for size in [5_000, 10_000].iter() {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(size),
+            size,
+            |b, &size| {
+                let mut rng = thread_rng();
+                let (smt, _keys) = random_shasmt(size, &mut rng);
+                b.iter(|| {
+                    let key = random_h256(&mut rng).into();
+                    smt.get(&key).unwrap();
+                });
+            }
+        );
+    }
+    group.finish();
 
     c.bench_function("ShaSmt generate merkle proof", |b| {
         let mut rng = thread_rng();
@@ -109,29 +117,37 @@ fn bench_hashes(c: &mut Criterion) {
 }
 
 fn bench_strings(c: &mut Criterion) {
-    c.bench_function_over_inputs(
-        "StringSmt update",
-        |b, &&size| {
-            b.iter(|| {
-                let mut rng = thread_rng();
-                random_stringsmt(size, &mut rng)
-            });
-        },
-        &[100, 10_000],
-    );
+    let mut group = c.benchmark_group("StringSmt update");
+    for size in [100, 10_000].iter() {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(size),
+            size,
+            |b, &size| {
+                b.iter(|| {
+                    let mut rng = thread_rng();
+                    random_stringsmt(size, &mut rng)
+                });
+            }
+        );
+    }
+    group.finish();
 
-    c.bench_function_over_inputs(
-        "StringSmt get",
-        |b, &&size| {
-            let mut rng = thread_rng();
-            let (smt, _keys) = random_stringsmt(size, &mut rng);
-            b.iter(|| {
-                let key = random_stringkey(&mut rng).into();
-                smt.get(&key).unwrap();
-            });
-        },
-        &[5_000, 10_000],
-    );
+    let mut group = c.benchmark_group("StringSmt get");
+    for size in [5_000, 10_000].iter() {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(size),
+            size,
+            |b, &size| {
+                let mut rng = thread_rng();
+                let (smt, _keys) = random_stringsmt(size, &mut rng);
+                b.iter(|| {
+                    let key = random_stringkey(&mut rng).into();
+                    smt.get(&key).unwrap();
+                });
+            }
+        );
+    }
+    group.finish();
 
     c.bench_function("StringSmt generate merkle proof", |b| {
         let mut rng = thread_rng();

--- a/benches/smt_benchmark.rs
+++ b/benches/smt_benchmark.rs
@@ -3,7 +3,7 @@ extern crate criterion;
 
 mod string_key;
 
-use criterion::{BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, Throughput};
 use rand::{thread_rng, Rng};
 use nam_sparse_merkle_tree::{
     sha256::Sha256Hasher, default_store::DefaultStore,
@@ -109,11 +109,20 @@ fn bench_hashes(c: &mut Criterion) {
         });
     });
 
-    c.bench_function("ShaSmt validate tree", |b| {
-        let mut rng = thread_rng();
-        let (smt, _) = random_shasmt(10_000, &mut rng);
-        b.iter(||{ assert!(smt.validate()) });
-    });
+    let mut group = c.benchmark_group("ShaSmt validate tree");
+    for size in [10_000, 100_000].iter() {
+        group.throughput(Throughput::Elements(*size as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(size),
+            size,
+            |b, &size| {
+                let mut rng = thread_rng();
+                let (smt, _) = random_shasmt(size, &mut rng);
+                b.iter(||{ assert!(smt.validate()) });
+            }
+        );
+    }
+    group.finish();
 }
 
 fn bench_strings(c: &mut Criterion) {
@@ -178,11 +187,20 @@ fn bench_strings(c: &mut Criterion) {
         });
     });
 
-    c.bench_function("StringSmt validate tree", |b| {
-        let mut rng = thread_rng();
-        let (smt, _) = random_stringsmt(10_000, &mut rng);
-        b.iter(||{ assert!(smt.validate()) });
-    });
+    let mut group = c.benchmark_group("StringSmt validate tree");
+    for size in [10_000, 100_000].iter() {
+        group.throughput(Throughput::Elements(*size as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(size),
+            size,
+            |b, &size| {
+                let mut rng = thread_rng();
+                let (smt, _) = random_stringsmt(size, &mut rng);
+                b.iter(||{ assert!(smt.validate()) });
+            }
+        );
+    }
+    group.finish();
 
 }
 

--- a/benches/smt_benchmark.rs
+++ b/benches/smt_benchmark.rs
@@ -5,7 +5,7 @@ mod string_key;
 
 use criterion::Criterion;
 use rand::{thread_rng, Rng};
-use sparse_merkle_tree::{
+use nam_sparse_merkle_tree::{
     sha256::Sha256Hasher, default_store::DefaultStore,
     tree::SparseMerkleTree, H256, Hash
 };

--- a/benches/smt_benchmark.rs
+++ b/benches/smt_benchmark.rs
@@ -189,6 +189,6 @@ fn bench_strings(c: &mut Criterion) {
 criterion_group!(
     name = benches;
     config = Criterion::default().sample_size(10);
-    targets = bench_strings
+    targets = bench_hashes, bench_strings
 );
 criterion_main!(benches);

--- a/benches/string_key.rs
+++ b/benches/string_key.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-use std::io::Write;
 use std::ops::Deref;
 
 use rand::Rng;
@@ -67,10 +65,10 @@ enum Identifier {
 /// Generate a random identifier complying with ICS
 fn random_identifier(id: Identifier, rng: &mut impl Rng) -> String {
     let range = match id {
-        Identifier::Port => (2..=128usize),
-        Identifier::Client => (9..=64),
-        Identifier::Connection => (10..=64),
-        Identifier::Channel => (8..=64),
+        Identifier::Port => 2..=128usize,
+        Identifier::Client => 9..=64,
+        Identifier::Connection => 10..=64,
+        Identifier::Channel => 8..=64,
     };
     generate(rng.gen_range(range), ICS_IDENTIFIER_CHARSET)
 }

--- a/benches/string_key.rs
+++ b/benches/string_key.rs
@@ -4,7 +4,7 @@ use std::ops::Deref;
 
 use rand::Rng;
 use random_string::generate;
-use sparse_merkle_tree::{InternalKey, Key};
+use nam_sparse_merkle_tree::{InternalKey, Key};
 
 pub const IBC_KEY_LIMIT: usize = 300;
 pub const ICS_IDENTIFIER_CHARSET: &str = "1234567890abcdefghijklmnopqrstuvwxyz._+-#[]<>";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! # Examples
 //!
 //! ```
-//! use sparse_merkle_tree::{
+//! use nam_sparse_merkle_tree::{
 //!     blake2b::Blake2bHasher, default_store::DefaultStore,
 //!     error::Error, MerkleProof,
 //!     SparseMerkleTree, traits::Value, H256, Hash,


### PR DESCRIPTION
This PR contains some benchmarking fix-ups and two commits with performance improvements to `SparseMerkleTree::validate()`:

- https://github.com/anoma/sparse-merkle-tree/commit/0ed2c1552136789ff65a337aaed31ca039fd7aec (validate_1 in plot)
- https://github.com/anoma/sparse-merkle-tree/commit/88b974d10c35ece30faf94e14b9c725d8e32d54b (validate_2 in plot)

These improvements address https://github.com/anoma/namada/issues/4701. When testing with both of the above commits applied, the node (intel sandy-bridge i7-2760QM 2.4ghz with `$NAMADA_DIR/db/` size of ~27GiB), `namadan` startup time went from 444 seconds to 19 seconds (~23x improvement).

Combined benchmark comparison for hashed keys:
![image](https://github.com/user-attachments/assets/756e1602-bdf6-4918-9f4d-187823dded63)
Combined benchmark comparison for string keys:
![image](https://github.com/user-attachments/assets/f65b96f2-7156-415f-9146-e602a4377669)
Combined benchmark is available here: https://github.com/b0dski/sparse-merkle-tree/tree/validate-bench

